### PR TITLE
Fix event "A different Time" + add a loading submod utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ A mod, consisting of fixes for Amazing Cultivation Simulator, tries to avoid con
 * Yaoguai Fragment Skill Level fix - Fixes Yaoguai Rebirthing related Skill issue, where Skill Levels aren't what they are supposed to be (not to be mixed up with the rerolling of Skills in general, which is a feature)
 * Fix Max Qi Story - Correct Story_2 and Story_Cold's reversed comparison, which prevents the extra Base Max Qi % outcomes to be triggered during a playthrough.
 * Various translations issues:
-** Level of Stable Mental State -> Mental State Change Speed
-** City adventuring: Purchase Timber -> Purchase Wood
-** City adventuring: Rob Commoners -> Kidnap Commoners
-** Zen Reflection: generating stamina -> consuming stamina
-** Missing category translation for the Bamboo Leftover in the Mini-Universe
-** Spiritwood block -> Spiritwood Timber
+    * Level of Stable Mental State -> Mental State Change Speed
+    * City adventuring: Purchase Timber -> Purchase Wood
+    * City adventuring: Rob Commoners -> Kidnap Commoners
+    * Zen Reflection: generating stamina -> consuming stamina
+    * Missing category translation for the Bamboo Leftover in the Mini-Universe
+    * Spiritwood block -> Spiritwood Timber
 * Fix Event A Different Time - The current event "A Different Time" is corrected to have its designed effect in-game.
 
 ## Install instructions

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A mod, consisting of fixes for Amazing Cultivation Simulator, tries to avoid con
 * Ancient Formations Condition fix - Implements the faulty conditions for Ancient Formation Nodes. Law Elements, and in some cases, Item requirements.
 * Yaoguai Fragment Skill Level fix - Fixes Yaoguai Rebirthing related Skill issue, where Skill Levels aren't what they are supposed to be (not to be mixed up with the rerolling of Skills in general, which is a feature)
 * Fix Max Qi Story - Correct Story_2 and Story_Cold's reversed comparison, which prevents the extra Base Max Qi % outcomes to be triggered during a playthrough.
+* Fix Event A Different Time - The current event "A Different Time" is corrected to have its designed effect in-game.
 
 ## Install instructions
 
@@ -57,6 +58,8 @@ For example, removing the Ancient Formation Condition fix requires the removal o
 * Settings\Practice\FabaoHelian\FabaoHelian.txt - For Qi Barrier Attachment Fix, utilizes ID's 72,73,74
 * Settings\Esoterica\EsotericaLables.txt - For Unorthodox Manual Fix, uses the entire OfficialEnglish file
 * Settings\Zhen\Node\ZhenNode_Suit.xml - For Ancient Formations Condition fix, nearly all entities changed
+* Scripts\main.lua - main LUA mod loading utility
+* Scripts\fix-event-a-different-time.lua - Related to "Fix Event A Different Time" change
 
 ### Functions
 
@@ -73,4 +76,4 @@ If the fixes exist as a standalone mod, include a link to it.
 
 ## Credits/Contributions
 
-* ucddj - Fix Max Qi Story
+* ucddj - Fix Max Qi Story, Fix Event A Different Time

--- a/Scripts/fix-event-a-different-time.lua
+++ b/Scripts/fix-event-a-different-time.lua
@@ -1,0 +1,19 @@
+local iguana_acs_fix = GameMain:GetMod("iguana_acs_fix")
+
+function fixEventADifferentTime()
+    local eventData41 = GameEventMgr:GetEventData(41)
+    eventData41.sParam1 = "34|35"
+    eventData41.fParam2 = 6 * 600
+end
+
+if iguana_acs_fix.submods == nil then
+    iguana_acs_fix.submods = {}
+end
+if iguana_acs_fix.submods["OnInit"] == nil then
+    iguana_acs_fix.submods["OnInit"] = {}
+end
+if iguana_acs_fix.submods["OnLoad"] == nil then
+    iguana_acs_fix.submods["OnLoad"] = {}
+end
+iguana_acs_fix.submods["OnInit"]["fix event 'a different time'"] = fixEventADifferentTime
+iguana_acs_fix.submods["OnLoad"]["fix event 'a different time'"] = fixEventADifferentTime

--- a/Scripts/main.lua
+++ b/Scripts/main.lua
@@ -1,0 +1,20 @@
+local iguana_acs_fix = GameMain:GetMod("iguana_acs_fix")
+local events = GameMain:GetMod("_Event");
+
+function functorAddSubmodInitializer(event)
+    return function ()
+        if iguana_acs_fix.submods == nil then
+            iguana_acs_fix.submods = {}
+        end
+        if iguana_acs_fix.submods[event] == nil then
+            iguana_acs_fix.submods[event] = {}
+        end
+        for title, submodFunc in pairs( iguana_acs_fix.submods[event]) do
+            print("iguana_acs_fix:"..event..": calling submod func "..title)
+            submodFunc()
+        end
+    end
+end
+
+iguana_acs_fix.OnInit = functorAddSubmodInitializer("OnInit")
+iguana_acs_fix.OnLoad = functorAddSubmodInitializer("OnLoad")

--- a/source/test/fix-event-a-different-time.lua
+++ b/source/test/fix-event-a-different-time.lua
@@ -1,0 +1,65 @@
+-- This is a test scenario for fix/event-a-different-time
+--
+-- It is meant to be used by entering code in the in-game console
+--
+
+--preliminary code to run
+local g = GameMain:GetMod("TestMod")
+
+g.testcase = function (title, firstValue, secondValue, verbose)
+    if verbose == nil then
+        verbose = false
+    end
+    local result = firstValue == secondValue
+    local text = tostring(result).." "..title
+    if verbose then
+        text = text.." | "..tostring(firstValue).." | "..tostring(secondValue)
+    end
+    print(text)
+    return result
+end
+
+-- to be used first
+function test_triggerEvent41_pre()
+    local g = GameMain:GetMod("TestMod")
+    xlua.private_accessible(CS.XiaWorld.GameEventMgr)
+    g.numWeightModifiers = GameEventMgr.Data.WeightModifiers.Count
+    g.curTime= World.TolSecond
+    g.hasEvent34WeightModifiers = GameEventMgr.WeightAddtion:ContainsKey(34)
+    g.hasEvent35WeightModifiers = GameEventMgr.WeightAddtion:ContainsKey(35)
+    g.curEvent34WeightMod = 0
+    g.curEvent35WeightMod = 0
+    if g.hasEvent34WeightModifiers then
+        g.curEvent34WeightMod =  GameEventMgr.WeightAddtion[34]
+    end
+    if g.hasEvent35WeightModifiers then
+        g.curEvent35WeightMod =  GameEventMgr.WeightAddtion[35]
+    end
+    GameEventMgr:TriggerEvent(41)
+end
+test_triggerEvent41_pre()
+
+
+--launch to test
+function test_triggerEvent41()
+    local g = GameMain:GetMod("TestMod")
+    local curTime = World.TolSecond
+    if(g.testcase("1 new Weight modifier", GameEventMgr.Data.WeightModifiers.Count, g.numWeightModifiers + 1)) then
+        local newWeightModifier = GameEventMgr.Data.WeightModifiers[g.numWeightModifiers]
+        g.testcase("new weight modifier concerns event 34", newWeightModifier.IDs[0],34)
+        g.testcase("new weight modifier concerns event 35", newWeightModifier.IDs[1],35)
+        g.testcase("1000 added weight", newWeightModifier.Value,1000)
+        g.testcase("ends in about 6 days", math.abs(newWeightModifier.EndTime - g.curTime - 3600) <= 60, true)
+        if (g.hasEvent34WeightModifiers) then
+            g.testcase("34:the new weight modifiers are applied as Weight Additions", GameEventMgr.WeightAddtion[34],g.curEvent34WeightMod +1000)
+        else
+            g.testcase("34: the new weight modifiers are applied as Weight Additions", GameEventMgr.WeightAddtion:ContainsKey(34), true)
+        end
+        if (g.hasEvent35WeightModifiers) then
+            g.testcase("35:the new weight modifiers are applied as Weight Additions", GameEventMgr.WeightAddtion[35],g.curEvent35WeightMod +1000)
+        else
+            g.testcase("35: the new weight modifiers are applied as Weight Additions", GameEventMgr.WeightAddtion:ContainsKey(35), true)
+        end
+    end
+end
+test_triggerEvent41()


### PR DESCRIPTION
It is not possible to directly change the Event through EventList.txt as the `InitEvents` function in `XiaWorld.GameEventMgr` only adds the generated EventData if the event map doesn't already contain the ID.

I've added a submod loading utility as I thought it would be convenient if future lua changes are to be expected.

Another possibility was to dynamically register (with `GetMod`) a new "mod" everytime but this can have unintended consequences.

The current syntax is a bit awkward, it's probably possible to improve it with LUA Metatables but I didn't want to use a somewhat advanced concept just for aesthetic purposes.