### PR TITLE
Fix/starting talisman perk

### DIFF
--- a/Language/OfficialEnglish/Settings/MapStories/MapStory_Item.xml
+++ b/Language/OfficialEnglish/Settings/MapStories/MapStory_Item.xml
@@ -1,0 +1,9 @@
+<Texts Type="Story">
+	<List>
+		<Text Name="Story_Item_E_FuBox">
+			<DisplayName>Polaris Chest</DisplayName>
+			<Desc>On the night of the attack, the talisman room was breached. You couldn't bear to see such rarities get looted, and so you risked your life to save a few.</Desc>
+			<Selections.0.Display>Open</Selections.0.Display>
+		</Text>
+	</List>
+</Texts>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A mod, consisting of fixes for Amazing Cultivation Simulator, tries to avoid con
     * Spiritwood block -> Spiritwood Timber
 * Fix Event A Different Time - The current event "A Different Time" is corrected to have its designed effect in-game.
 * Fix Female Fei Constitution - for some base age range the Female Fei has a weirdly high baser values.
+* Change Talisman of Foreseer from "Advanced Talismans" and "Luck with Talisman Room" to 96% quality, so it actually has an adventure exploration effect
 
 ## Install instructions
 
@@ -52,6 +53,7 @@ For example, removing the Ancient Formation Condition fix requires the removal o
 
 * (MapStory_System) SystemLearnGreateBuilding - For Daemonia Wonder Fix
 * (MapStory_FillingLv1) Story_2 and Story_Cold - "Fix Max Qi Story" related
+* (MapStory_Item) Story_Item_E_FuBox - Change Talisman of Foreseer in starting experiences
 
 ### Buildings
 

--- a/Settings/MapStories/MapStory_Item.xml
+++ b/Settings/MapStories/MapStory_Item.xml
@@ -1,0 +1,17 @@
+<Stories><List>	
+	<Story Name="Story_Item_E_FuBox" Parent="BaseFillingStory">
+		<DisplayName>太一宝匣</DisplayName>
+		<Desc>在灭门之夜，你发现云箓房禁法被破，你不忍派中至宝尽数被洗劫，于是拼死闯入其中，将几张珍贵的符箓装入匣中带走。</Desc>
+		<Kind>None</Kind>
+		<Selections>
+			<li>
+				<Display>打开</Display>
+				<OKResult>
+				<![CDATA[	
+				me:AddMsg(XT("[NAME]开了太一宝匣，取出其中的物件。"));me:DropSpell(1, "Spell_RecoveryPower", 0.95);me:DropSpell(1, "Spell_GlobalEfficiency", 0.95);me:DropSpell(1, "Spell_VisionRadius", 0.96);me:DropSpell(1, "Spell_MoveSpeed2", 0.95);story:RemoveBindItem();
+				]]>		
+				</OKResult>
+			</li>
+		</Selections>
+	</Story>
+</List></Stories>


### PR DESCRIPTION
Another debatable one : change the T5 talisman of foreseer's bonus to 96% quality so it has an Exploration Speed effect.

Adding it with the Trimerous Essence Pill one as a kind of small functional change that should go along with the game's intention.