### PR TITLE
Fix refinement chance of success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.vs
 *.cache
 source/iguana_acs_fix/.vs/iguana_acs_fix/v16/.suo
 iguana_acs_fix.pdb

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A mod, consisting of fixes for Amazing Cultivation Simulator, tries to avoid con
 * Greedy Personality Heart Unlockable - Changes the gifting related threshold from 70 to 60, meaning attainable before Heart Guard has been unlocked.
 * Fix the Artifact Power Bonus for  Xianxian and Xiuxiu (panda pets)
 * Fix State 3 Equilibrium : The game may sometimes mistakenly displays your disciples has having food equilibrium despite them still having unsustained food needs
-
+* Fix Refinement success chance estimation - Properly evaluates the specter, tao and spiritual refinement success chances.
 ## Install instructions
 
 Download the latest release, extract the iguana_acs_fix into the Mods folder. If the release is behind the Main version and you want to update to the preview version, download the repository directly, and extract the contents of the archive into the iguana_acs_fix folder, located in the Mods folder.
@@ -110,6 +110,7 @@ For example, removing the Ancient Formation Condition fix requires the removal o
 
 * XiaWorld.HumanoidEvolutionMgr.ModifyNpcByFrag - For Yaoguai Fragment Skill Level fix, a Postfix, compatible with other Postfixes to the same function
 * Wnd_JianghuTalk.GiveGift2Target - For Greedy Personality Heart Unlockable, a Transpiler changing the ldc.r4:70 to ldc.r4:60
+* UILogicMode_IndividualCommand.CheckThing - Fix Refinement success chance estimation
 
 ## How to Contribute
 

--- a/source/iguana_acs_fix/RefinementSuccessChance.cs
+++ b/source/iguana_acs_fix/RefinementSuccessChance.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using XiaWorld;
+using HarmonyLib;
+using UnityEngine;
+
+namespace iguana_acs_fix
+{
+    public class RefinementSuccessChance
+	{
+        [HarmonyPatch(typeof(UILogicMode_IndividualCommand), "CheckThing")]
+        private class ChangeHeadMessage
+        {
+            private static void Postfix(ref UILogicMode_IndividualCommand __instance, Thing t, Thing ___BindThing)
+            {
+                g_emIndividualCommandType Type = __instance.Type;
+                if (Type != g_emIndividualCommandType.SoulCrystalLingPowerUp && Type != g_emIndividualCommandType.DaoCuiPowerUp && Type != g_emIndividualCommandType.SoulCrystalYouPowerUp) { return; }
+                ItemThing targetItem = t as ItemThing;
+                Npc casterNpc = ___BindThing as Npc;
+                float BAddP = 0f;
+                // While the game considers the casterNpc's room for the cast, using the item's room is better in case the chance is checked with the NPC in another room
+                // This could maybe create some edge errors but infrequent enough to be ignored.
+                if (targetItem.AtRoom != null && targetItem.AtRoom.FengShui >= g_emFengshuiRank.Bad) 
+                {
+                    BAddP = ((float)targetItem.AtRoom.FengShui - 3f) * 0.01f;
+                }
+                float sentientSoulGemMultiplier = 0;
+                if (casterNpc.CheckSpecialFlag(g_emNpcSpecailFlag.UpgradeCuiLian) != 0)
+                {
+                    sentientSoulGemMultiplier = 1;
+                }
+                float successChance = (1 + sentientSoulGemMultiplier) * Mathf.Pow(GameDefine.SOULCRYSTALYOU_BASE + BAddP, targetItem.Rate + targetItem.YouAddDaoPower);
+                switch (Type)
+                {
+                    case g_emIndividualCommandType.DaoCuiPowerUp:
+                        Wnd_GameMain.Instance.ChangeHeadMsg(string.Format(TFMgr.Get("当前品阶：{1} 道淬成功率：{0} {2}"), GameUlt.GetRateString(successChance), targetItem.Rate, (targetItem.Rate < 12) ? string.Empty : TFMgr.Get("[color=#FF0000](无提升)[/color]")));
+                        break;
+                    case g_emIndividualCommandType.SoulCrystalLingPowerUp:
+                        Wnd_GameMain.Instance.ChangeHeadMsg(string.Format(TFMgr.Get("灵淬成功率：{0}"), GameUlt.GetRateString(successChance)));
+                        break;
+                    case g_emIndividualCommandType.SoulCrystalYouPowerUp:
+                        Wnd_GameMain.Instance.ChangeHeadMsg(string.Format(TFMgr.Get("当前品阶：{1} 幽淬成功率：{0} {2}"), GameUlt.GetRateString(successChance), targetItem.Rate, (targetItem.Rate < 12) ? string.Empty : TFMgr.Get("[color=#FF0000](无提升)[/color]")));
+                        break;
+                    default:
+                        break;
+
+                }
+            }
+        }
+    }
+}

--- a/source/iguana_acs_fix/iguana_acs_fix.csproj
+++ b/source/iguana_acs_fix/iguana_acs_fix.csproj
@@ -57,10 +57,15 @@
       <HintPath>..\..\..\..\Amazing Cultivation Simulator_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\Amazing Cultivation Simulator_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainPatches.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RefinementSuccessChance.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/iguana_acs_fix/iguana_acs_fix.sln
+++ b/source/iguana_acs_fix/iguana_acs_fix.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "iguana_acs_fix", "iguana_acs_fix.csproj", "{04FE2D19-F42F-4BF9-A92C-D12F4E848AF9}"
 EndProject


### PR DESCRIPTION
Fixes #52 .

The displayed chance is still quite inaccurate, due to the call to "GetRateString" which rounds down to the nearest ten (for translation reasons?)
This could be the subject of a functional change but I don't see it as a priority myself right now (will depend on feedback).

As mentioned, the evaluation of the room effect is made from the item's current room as it was the most accurate, and the rare issues it could create are not particularly bothering since it's only an estimation.